### PR TITLE
#33546 Add decorative toggle to control alt text input field

### DIFF
--- a/src/plugins/image/main/ts/api/Settings.ts
+++ b/src/plugins/image/main/ts/api/Settings.ts
@@ -36,6 +36,10 @@ const hasImageCaption = function (editor) {
   return editor.settings.image_caption === true ? true : false;
 };
 
+const hasImageDecorative = function (editor) {
+  return editor.settings.image_decorative === true ? true : false;
+};
+
 const getImageList = function (editor) {
   return editor.getParam('image_list', false);
 };
@@ -72,6 +76,7 @@ export default {
   hasDescription,
   hasImageTitle,
   hasImageCaption,
+  hasImageDecorative,
   getImageList,
   hasUploadUrl,
   hasUploadHandler,

--- a/src/plugins/image/main/ts/core/ImageData.ts
+++ b/src/plugins/image/main/ts/core/ImageData.ts
@@ -18,6 +18,7 @@ const DOM = DOMUtils.DOM;
 interface ImageData {
   src: string;
   alt: string;
+  decorative: boolean;
   title: string;
   width: string;
   height: string;
@@ -71,6 +72,10 @@ const getStyle = (image: HTMLElement, name: string): string => {
 
 const hasCaption = (image: HTMLElement): boolean => {
   return image.parentNode !== null && image.parentNode.nodeName === 'FIGURE';
+};
+
+const isDecorative = (image: HTMLElement): boolean => {
+  return image.getAttribute('decorative') === 'true';
 };
 
 const setAttrib = (image: HTMLElement, name: string, value: string) => {
@@ -161,6 +166,7 @@ const defaultData = (): ImageData => {
   return {
     src: '',
     alt: '',
+    decorative: false,
     title: '',
     width: '',
     height: '',
@@ -248,6 +254,7 @@ const read = (normalizeCss: CssNormalizer, image: HTMLElement): ImageData => {
   return {
     src: getAttrib(image, 'data-obvius-src') || getAttrib(image, 'src'),
     alt: getAttrib(image, 'alt'),
+    decorative: isDecorative(image),
     title: getAttrib(image, 'title'),
     width: getSize(image, 'width'),
     height: getSize(image, 'height'),
@@ -361,6 +368,7 @@ const write = (normalizeCss: CssNormalizer, newData: ImageData, image: HTMLEleme
   updateProp(image, oldData, newData, 'caption', (image, _name, _value) => toggleCaption(image));
   updateProp(image, oldData, newData, 'src', setAttrib);
   updateProp(image, oldData, newData, 'alt', setAttrib);
+  updateProp(image, oldData, newData, 'decorative', setAttrib);
   updateProp(image, oldData, newData, 'title', setAttrib);
   updateProp(image, oldData, newData, 'width', setSize('width', normalizeCss));
   updateProp(image, oldData, newData, 'height', setSize('height', normalizeCss));

--- a/src/plugins/image/main/ts/ui/MainTab.ts
+++ b/src/plugins/image/main/ts/ui/MainTab.ts
@@ -3,6 +3,19 @@ import Settings from '../api/Settings';
 import Utils from '../core/Utils';
 import SizeManager from './SizeManager';
 
+const onDecorativeChange = function (evt, editor) {
+  const control = evt.control;
+  const rootControl = control.rootControl;
+  const altControl = rootControl.find('#alt');
+  const disable = control.checked();
+
+  if (disable) {
+    altControl.value('');
+  }
+
+  altControl.disabled(disable);
+};
+
 const onSrcChange = function (evt, editor) {
   let srcURL, prependURL, absoluteURLPattern;
   const meta = evt.meta || {};
@@ -62,6 +75,18 @@ const getGeneralItems = function (editor, imageListCtrl) {
 
   if (Settings.hasDescription(editor)) {
     generalFormItems.push({ name: 'alt', type: 'textbox', label: 'Image description' });
+  }
+
+  if (Settings.hasImageDecorative(editor)) {
+    generalFormItems.push(
+      {
+        name: 'decorative',
+        type: 'checkbox',
+        label: 'Decorative image',
+        onchange (evt) {
+          onDecorativeChange(evt, editor);
+        }
+      });
   }
 
   if (Settings.hasImageTitle(editor)) {

--- a/src/skins/obvius/main/less/Skin.less
+++ b/src/skins/obvius/main/less/Skin.less
@@ -10,4 +10,7 @@
 .mce-window[aria-label="Insert/edit image"] .mce-form[role="tabpanel"]:nth-child(3) .mce-formitem:nth-child(5) {
     display: none;
 }
-
+.mce-textbox.mce-disabled {
+    background-color: #dfdfdf;
+    cursor: default;
+}


### PR DESCRIPTION
Tilføjer en checkbox, der indikerer at et billede er dekorativt og dermed ikke skal have en alt-text. Ved afkrydsning slettes indholdet af alt-tekstfeltet, som også gøres inaktivt vha. en `disabled`-attribut. Derudover tilføjes lidt styling, så det er visuelt tydeligt, at feltet er deaktiveret. Feltet gen-aktiveres, når man fjerner afkrydsningen.

Ideelt ville indholdet af alt-tekstfeltet bevares, når man sætter hak i checkboxen, men jeg har valgt den simplere løsning for ikke at skulle håndtere sletningen af indholdet på det tidspunkt man trykker "Ok" i dialogen.

Screenshot:
![decorative_image](https://user-images.githubusercontent.com/3662366/72508357-d3785900-3845-11ea-810a-2f7556ff105c.png)

Funktionaliteten slås til og fra med `image_decorative = [true | false]` i `load_tinymce4.mason`. Denne indstilling samt to linjers oversættelser ligger i den relevante branch i `www.ku.dk`-kodebasen.

Afventer i skrivende stund godkendelse fra KU men er klar til review.