### PR TITLE
[#34212] Add alt text validation, propagate error and prevent dialog close

### DIFF
--- a/src/plugins/image/main/ts/core/ImageData.ts
+++ b/src/plugins/image/main/ts/core/ImageData.ts
@@ -362,6 +362,14 @@ const normalized = (set: (image: HTMLElement, value: string) => void, normalizeC
   };
 };
 
+const validateAlt = (newData: ImageData): boolean => {
+  if (newData.alt === '' && !newData.decorative) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
 const write = (normalizeCss: CssNormalizer, newData: ImageData, image: HTMLElement) => {
   const oldData = read(normalizeCss, image);
 
@@ -389,5 +397,6 @@ export {
   isImage,
   create,
   read,
-  write
+  write,
+  validateAlt
 };

--- a/src/plugins/image/main/ts/core/ImageSelection.ts
+++ b/src/plugins/image/main/ts/core/ImageSelection.ts
@@ -9,7 +9,7 @@
  */
 
 import { Editor } from 'tinymce/core/api/Editor';
-import { defaultData, read, ImageData, create, isFigure, write } from 'tinymce/plugins/image/core/ImageData';
+import { defaultData, read, ImageData, create, isFigure, write, validateAlt } from 'tinymce/plugins/image/core/ImageData';
 import Utils from 'tinymce/plugins/image/core/Utils';
 import { HTMLElement } from '@ephox/dom-globals';
 
@@ -112,6 +112,10 @@ const writeImageDataToSelection = (editor: Editor, data: ImageData) => {
 
 const insertOrUpdateImage = (editor: Editor, data: ImageData) => {
   const image = getSelectedImage(editor);
+  if (!validateAlt(data)) {
+    editor.windowManager.alert('You must either fill in the Alternate Text box or specify that the image is decorative.');
+    return false;
+  }
   if (image) {
     if (data.src) {
       writeImageDataToSelection(editor, data);
@@ -121,6 +125,7 @@ const insertOrUpdateImage = (editor: Editor, data: ImageData) => {
   } else if (data.src) {
     insertImageAtCaret(editor, data);
   }
+  return true;
 };
 
 export {

--- a/src/plugins/image/main/ts/ui/Dialog.ts
+++ b/src/plugins/image/main/ts/ui/Dialog.ts
@@ -25,7 +25,12 @@ const submitForm = (editor: Editor, evt) => {
 
   editor.undoManager.transact(() => {
     const data = Merger.merge(readImageDataFromSelection(editor), win.toJSON());
-    insertOrUpdateImage(editor, data);
+    // Do validation, stop propagation if data not valid
+    const success = insertOrUpdateImage(editor, data);
+    if (!success) {
+      evt.preventDefault();
+      return;
+    }
   });
 
   editor.editorUpload.uploadImagesAuto();


### PR DESCRIPTION
Adds validation logic to `ImageData`, uses validation in `ImageSelection` when inserting or updating image and returns the result to the dialog itself. If validation fails, an alert is shown, save event propagation is stopped and the image dialog remains open.

Can be tested on any tinymce editor on cmstest01.ku.dk or by checking out `feature/ticket34212_tinymce_validate_alt_text_on_save` in `www.ku.dk` codebase which contains the new minified `Image` plugin as well as an error message translation.