### PR TITLE
#31210 Always add alt attribute

### DIFF
--- a/src/plugins/image/main/ts/core/ImageData.ts
+++ b/src/plugins/image/main/ts/core/ImageData.ts
@@ -375,7 +375,8 @@ const write = (normalizeCss: CssNormalizer, newData: ImageData, image: HTMLEleme
 
   updateProp(image, oldData, newData, 'caption', (image, _name, _value) => toggleCaption(image));
   updateProp(image, oldData, newData, 'src', setAttrib);
-  updateProp(image, oldData, newData, 'alt', setAttrib);
+  // Always set alt even if data.alt is an empty string
+  setAttrib(image, 'alt', newData.alt);
   updateProp(image, oldData, newData, 'decorative', setAttrib);
   updateProp(image, oldData, newData, 'title', setAttrib);
   updateProp(image, oldData, newData, 'width', setSize('width', normalizeCss));


### PR DESCRIPTION
Fixes bug where pre-existing images without an alt attribute would not get a new one on save even with decorative toggle on.