### PR TITLE
#35617 Disable and clear title field when marking image decorative

### DIFF
--- a/src/plugins/image/main/ts/ui/MainTab.ts
+++ b/src/plugins/image/main/ts/ui/MainTab.ts
@@ -7,13 +7,16 @@ const onDecorativeChange = function (evt, editor) {
   const control = evt.control;
   const rootControl = control.rootControl;
   const altControl = rootControl.find('#alt');
+  const titleControl = rootControl.find('#title');
   const disable = control.checked();
 
   if (disable) {
     altControl.value('');
+    titleControl.value('');
   }
 
   altControl.disabled(disable);
+  titleControl.disabled(disable);
 };
 
 const onSrcChange = function (evt, editor) {


### PR DESCRIPTION
Makes title field behave the same way alt text field does; when image is marked decorative, title field is cleared and disabled.